### PR TITLE
Expose the more general provider API

### DIFF
--- a/lib/hover-tooltips.d.ts
+++ b/lib/hover-tooltips.d.ts
@@ -2,7 +2,7 @@
 export declare function debug(msg: string): void;
 export declare class HoverTooltips {
     private editorWatch;
-    provider: Hover.Provider;
+    provider: Hover.IProvider;
     syntax: string;
     activate(): void;
     deactivate(): void;

--- a/lib/hover-tooltips.js
+++ b/lib/hover-tooltips.js
@@ -4,7 +4,6 @@ var emissary = require('emissary');
 var fs = require('fs');
 var tooltipView = require('./tooltipView');
 var TooltipView = tooltipView.TooltipView;
-var Info = require('./info');
 var Subscriber = emissary.Subscriber;
 function debug(msg) {
     if (false) {
@@ -127,8 +126,7 @@ var HoverTooltips = (function () {
         var _this = this;
         this.editorWatch = atom.workspace.observeTextEditors(function (editor) {
             var editorView = atom_space_pen_views_1.$(atom.views.getView(editor));
-            var iprovider = Info.provider(_this.provider);
-            var attach = mkAttach(iprovider);
+            var attach = mkAttach(_this.provider);
             attach(editorView, editor);
         });
     };

--- a/lib/hover-tooltips.ts
+++ b/lib/hover-tooltips.ts
@@ -170,15 +170,14 @@ export class HoverTooltips {
 
   private editorWatch: AtomCore.Disposable;
 
-  provider:Hover.Provider;
+  provider:Hover.IProvider;
 
   syntax:string;
 
   activate() {
     this.editorWatch = atom.workspace.observeTextEditors((editor:AtomCore.IEditor) => {
       var editorView = $(atom.views.getView(editor));
-      var iprovider  = Info.provider(this.provider);
-      var attach = mkAttach(iprovider);
+      var attach = mkAttach(this.provider);
       attach(editorView, editor);
     });
   }

--- a/lib/tooltipView.js
+++ b/lib/tooltipView.js
@@ -1,8 +1,7 @@
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var view = require('./view');
 var $ = view.$;

--- a/lib/tooltipView.ts
+++ b/lib/tooltipView.ts
@@ -3,7 +3,7 @@ import view = require('./view');
 
 var $ = view.$;
 
-interface Rect {
+export interface Rect {
     left: number;
     right: number;
     top: number;

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -17,8 +17,11 @@
     "files": [
         "./hover-tooltips.d.ts",
         "./hover-tooltips.ts",
+        "./info.d.ts",
         "./info.ts",
+        "./tooltipView.d.ts",
         "./tooltipView.ts",
+        "./view.d.ts",
         "./view.ts"
     ]
 }

--- a/lib/view.js
+++ b/lib/view.js
@@ -1,8 +1,7 @@
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
     function __() { this.constructor = d; }
-    __.prototype = b.prototype;
-    d.prototype = new __();
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
 var sp = require('atom-space-pen-views');
 var View = (function (_super) {

--- a/typings/hover.d.ts
+++ b/typings/hover.d.ts
@@ -19,7 +19,7 @@ declare module Hover {
     info:string;
   }
 
-  type IProvider = (p:Hover.Position) => Promise<Hover.Info>;
+  export type IProvider = (p:Hover.Position) => Promise<Hover.Info>;
 
   export interface Provider {
     command(p:Hover.Position):Hover.Command;


### PR DESCRIPTION
Good start to a package, would be great if this could be polished up a bit and get some use, I see at least 3-4 implementations of this same thing for atom.

In my case I didn't want to run an external command directly, I think the better API would be expose the basic position->result promise and then maybe include a helper (as you already have) to exec a command.

(BTW, had some trouble building, possibly type definitions missing for `atom-space-pen-views`?)
