### PR TITLE
Replace removed scrollTop references

### DIFF
--- a/lib/hover-tooltips.js
+++ b/lib/hover-tooltips.js
@@ -1,4 +1,3 @@
-/// <reference path="../typings/hover.d.ts" />
 var atom_space_pen_views_1 = require("atom-space-pen-views");
 var emissary = require('emissary');
 var fs = require('fs');
@@ -30,9 +29,7 @@ function mkAttach(iprovider) {
         var exprTypeTooltip = null;
         var lastExprTypeBufferPt;
         subscriber.subscribe(scroll, 'mousemove', function (e) {
-            var pixelPt = pixelPositionFromMouseEvent(editorView, e);
-            var screenPt = editor.screenPositionForPixelPosition(pixelPt);
-            var bufferPt = editor.bufferPositionForScreenPosition(screenPt);
+            var bufferPt = bufferPositionForMouseEvent(e);
             if (lastExprTypeBufferPt && lastExprTypeBufferPt.isEqual(bufferPt) && exprTypeTooltip)
                 return;
             lastExprTypeBufferPt = bufferPt;
@@ -49,11 +46,7 @@ function mkAttach(iprovider) {
         function showExpressionType(e) {
             if (exprTypeTooltip)
                 return;
-            var pixelPt = pixelPositionFromMouseEvent(editorView, e);
-            pixelPt.top += editor.displayBuffer.getScrollTop();
-            pixelPt.left += editor.displayBuffer.getScrollLeft();
-            var screenPt = editor.screenPositionForPixelPosition(pixelPt);
-            var bufferPt = editor.bufferPositionForScreenPosition(screenPt);
+            var bufferPt = bufferPositionForMouseEvent(e);
             var curCharPixelPt = rawView.pixelPositionForBufferPosition([bufferPt.row, bufferPt.column]);
             var nextCharPixelPt = rawView.pixelPositionForBufferPosition([bufferPt.row, bufferPt.column + 1]);
             if (curCharPixelPt.left >= nextCharPixelPt.left)
@@ -103,6 +96,10 @@ function mkAttach(iprovider) {
             exprTypeTooltip.$.remove();
             exprTypeTooltip = null;
         }
+        function bufferPositionForMouseEvent(e) {
+            var screenPt = rawView.component.screenPositionForMouseEvent(e);
+            return editor.bufferPositionForScreenPosition(screenPt);
+        }
     };
 }
 function getEditorPosition(editor) {
@@ -112,16 +109,6 @@ function getEditorPosition(editor) {
 function getEditorPositionForBufferPosition(editor, bufferPos) {
     var buffer = editor.getBuffer();
     return buffer.characterIndexForPosition(bufferPos);
-}
-function pixelPositionFromMouseEvent(editorView, event) {
-    var clientX = event.clientX, clientY = event.clientY;
-    var linesClientRect = getFromShadowDom(editorView, '.lines')[0].getBoundingClientRect();
-    var top = clientY - linesClientRect.top;
-    var left = clientX - linesClientRect.left;
-    return { top: top, left: left };
-}
-function screenPositionFromMouseEvent(editorView, event) {
-    return editorView.getModel().screenPositionForPixelPosition(pixelPositionFromMouseEvent(editorView, event));
 }
 function provider(p) {
     return Info.provider(p);

--- a/lib/hover-tooltips.ts
+++ b/lib/hover-tooltips.ts
@@ -47,9 +47,7 @@ return function attach(editorView : JQuery, editor: AtomCore.IEditor){
     var lastExprTypeBufferPt: any;
 
     subscriber.subscribe(scroll, 'mousemove', (e) => {
-        var pixelPt = pixelPositionFromMouseEvent(editorView, e)
-        var screenPt = editor.screenPositionForPixelPosition(pixelPt)
-        var bufferPt = editor.bufferPositionForScreenPosition(screenPt)
+        var bufferPt = bufferPositionForMouseEvent(e);
         if (lastExprTypeBufferPt && lastExprTypeBufferPt.isEqual(bufferPt) && exprTypeTooltip)
             return;
 
@@ -74,11 +72,8 @@ return function attach(editorView : JQuery, editor: AtomCore.IEditor){
         // If we are already showing we should wait for that to clear
         if (exprTypeTooltip) return;
 
-        var pixelPt = pixelPositionFromMouseEvent(editorView, e);
-        pixelPt.top += editor.displayBuffer.getScrollTop();
-        pixelPt.left += editor.displayBuffer.getScrollLeft();
-        var screenPt = editor.screenPositionForPixelPosition(pixelPt);
-        var bufferPt = editor.bufferPositionForScreenPosition(screenPt);
+        var bufferPt = bufferPositionForMouseEvent(e);
+
         var curCharPixelPt = rawView.pixelPositionForBufferPosition([bufferPt.row, bufferPt.column]);
         var nextCharPixelPt = rawView.pixelPositionForBufferPosition([bufferPt.row, bufferPt.column + 1]);
 
@@ -137,6 +132,11 @@ return function attach(editorView : JQuery, editor: AtomCore.IEditor){
         exprTypeTooltip.$.remove();
         exprTypeTooltip = null;
     }
+
+    function bufferPositionForMouseEvent(e: MouseEvent) {
+      var screenPt = rawView.component.screenPositionForMouseEvent(e);
+      return editor.bufferPositionForScreenPosition(screenPt);
+    }
 }
 }
 
@@ -153,17 +153,7 @@ function getEditorPositionForBufferPosition(editor: AtomCore.IEditor, bufferPos:
     return buffer.characterIndexForPosition(bufferPos);
 }
 
-function pixelPositionFromMouseEvent(editorView, event: MouseEvent) {
-    var clientX = event.clientX, clientY = event.clientY;
-    var linesClientRect = getFromShadowDom(editorView, '.lines')[0].getBoundingClientRect();
-    var top = clientY - linesClientRect.top;
-    var left = clientX - linesClientRect.left;
-    return { top: top, left: left };
-}
 
-function screenPositionFromMouseEvent(editorView, event) {
-    return editorView.getModel().screenPositionForPixelPosition(pixelPositionFromMouseEvent(editorView, event));
-}
 
 /*************************************************************************/
 /* Creating a Provider                                                   */


### PR DESCRIPTION
Fixes exceptions when calculating the position from mouse events: https://github.com/nwolverson/atom-ide-purescript/issues/34. Using suggestion from https://github.com/atom/atom/issues/7193

```
At /home/jutaro/.atom/packages/ide-purescript/node_modules/hover-tooltips/lib/hover-tooltips.js:53

TypeError: editor.displayBuffer.getScrollTop is not a function
  at showExpressionType (/home/jutaro/.atom/packages/ide-purescript/node_modules/hover-tooltips/lib/hover-tooltips.js:53:49)
  at /home/jutaro/.atom/packages/ide-purescript/node_modules/hover-tooltips/lib/hover-tooltips.js:40:63
```
